### PR TITLE
cmake: fix for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.12) # ensure we're running on a modern CMake.
                                      # add the Kitware apt repository via the instructions at https://apt.kitware.com/
 
 ### ► set the project to build using the ARM gcc cross-compilation toolchain with Cortex-M4 specific options
-set(CMAKE_TOOLCHAIN_FILE "cmake/gcc_stm32f4.cmake")
+set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/gcc_stm32f4.cmake")
 
 ### Work around a GCC bug.
 # By default, CMake passes include directories for imported targets to the compiler as -isystem flags. However, all

--- a/cmake/gcc_stm32.cmake
+++ b/cmake/gcc_stm32.cmake
@@ -9,16 +9,20 @@ if(TOOLCHAIN_PATH)
 	set(PATH_PREFIX ${TOOLCHAIN_PATH_ABSOLUTE}/bin/)
 endif()
 
-set(CMAKE_C_COMPILER   "${PATH_PREFIX}${triple}-gcc")
-set(CMAKE_CXX_COMPILER "${PATH_PREFIX}${triple}-g++")
-set(CMAKE_ASM_COMPILER "${PATH_PREFIX}${triple}-gcc")
+if(WIN32)
+	set(toolchain_binext ".exe")
+endif()
+
+set(CMAKE_C_COMPILER   "${PATH_PREFIX}${triple}-gcc${toolchain_binext}")
+set(CMAKE_CXX_COMPILER "${PATH_PREFIX}${triple}-g++${toolchain_binext}")
+set(CMAKE_ASM_COMPILER "${PATH_PREFIX}${triple}-gcc${toolchain_binext}")
 
 # don't try to link executables during internal compiler checks,
 # since linking will fail without a linker script.
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
-set(CMAKE_OBJCOPY  "${PATH_PREFIX}${triple}-objcopy")
-set(CMAKE_OBJDUMP  "${PATH_PREFIX}${triple}-objdump")
-set(CMAKE_SIZE     "${PATH_PREFIX}${triple}-size")
-set(CMAKE_DEBUGGER "${PATH_PREFIX}${triple}-gdb")
-set(CMAKE_CPPFILT  "${PATH_PREFIX}${triple}-c++filt")
+set(CMAKE_OBJCOPY  "${PATH_PREFIX}${triple}-objcopy${toolchain_binext}")
+set(CMAKE_OBJDUMP  "${PATH_PREFIX}${triple}-objdump${toolchain_binext}")
+set(CMAKE_SIZE     "${PATH_PREFIX}${triple}-size${toolchain_binext}")
+set(CMAKE_DEBUGGER "${PATH_PREFIX}${triple}-gdb${toolchain_binext}")
+set(CMAKE_CPPFILT  "${PATH_PREFIX}${triple}-c++filt${toolchain_binext}")


### PR DESCRIPTION
- `CMAKE_TOOLCHAIN_FILE` should be referenced to `CMAKE_CURRENT_SOURCE_DIR`
- for some infernal reason, we need to add `.exe` to the end of compiler paths for CMake 3.15 on Windows!? it partially finds the compiler(s) without it but can't actually run the smoketests to make sure it can build c/c++ files without the `.exe`, so i assume it's logic being different in two different places.