### PR TITLE
printf() via newlib: implement necessary syscalls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ check_ipo_supported(RESULT is_ipo_supported)
 add_compile_options(-fdiagnostics-color=always)
 
 ### ► add the Flight Control Unit firmware as an executable target
-add_executable(fcu src/fcu.cpp src/drivers/max31855.cpp)
+add_executable(fcu src/syscalls.c src/fcu.cpp src/drivers/max31855.cpp)
 set_target_properties(fcu PROPERTIES SUFFIX ".elf")
 target_include_directories(fcu PRIVATE src/ src/cfg/)
 

--- a/src/drivers/max31855.cpp
+++ b/src/drivers/max31855.cpp
@@ -1,11 +1,11 @@
 #include <array>
 #include <algorithm>
+#include <cstdio>
 #include <boost/units/systems/temperature/celsius.hpp>
 #include <boost/units/systems/si.hpp>
 #include "util/impl_bit_cast.h"
 
 #include "max31855.h"
-#include "chprintf.h"
 
 using namespace boost::units;
 using namespace boost::units::si;
@@ -64,14 +64,14 @@ bool Max31855Reading::fault_open() const {
 
 quantity<absolute<celsius::temperature>, float> Max31855Reading::internal_temp() const {
 #ifdef MAX31855_DEBUG
-    chprintf((BaseSequentialStream*)&SD3, "[max31855] itemp extracted raw: %X from %X\n", (this->inner >> 4) & (0b111111111111), this->inner);
+    printf("[max31855] itemp extracted raw: %X from %X\n", (this->inner >> 4) & (0b111111111111), this->inner);
 #endif
 
     return demangle_temp_internal((this->inner >> 4) & (0b111111111111));
 }
 quantity<absolute<celsius::temperature>, float> Max31855Reading::thermocouple_temp() const {
 #ifdef MAX31855_DEBUG
-    chprintf((BaseSequentialStream*)&SD3, "[max31855] ttemp extracted raw: %X from %X\n", (this->inner >> 18), this->inner);
+    printf("[max31855] ttemp extracted raw: %X from %X\n", (this->inner >> 18), this->inner);
 #endif
 
     return demangle_temp_thermocouple(this->inner >> 18);
@@ -95,7 +95,7 @@ uint32_t Max31855::raw_spi_read() {
 #endif
 
 #ifdef MAX31855_DEBUG
-    chprintf((BaseSequentialStream*)&SD3, "[max31855] raw data: %x %x %x %x\n", data[0], data[1], data[2], data[3]);
+    printf("[max31855] raw data: %x %x %x %x\n", data[0], data[1], data[2], data[3]);
 #endif
 
     return data[0]<<24 | data[1] << 16 | data[2] << 8 | data[3] << 0;

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1,0 +1,64 @@
+#include <errno.h>
+#include <sys/unistd.h> // STDOUT_FILENO, STDERR_FILENO
+#include <sys/stat.h> // S_IFCHR
+#include "hal.h"
+
+#define PRINTF_STREAM_DEVICE (BaseSequentialStream*)&SD3
+
+__attribute__((used))
+int _write(int file, char *ptr, int len) {
+   if ((file != STDOUT_FILENO) && (file != STDERR_FILENO)) {
+      errno = EBADF;
+      return -1;
+   }
+
+   int txferred = streamWrite(PRINTF_STREAM_DEVICE, ptr, len);
+
+   return txferred;
+}
+
+__attribute__((used))
+int _read(int file, char *ptr, int len) {
+  return 0;
+}
+
+__attribute__((used))
+int _close_r(struct _reent *r, int file) {
+  return 0;
+}
+
+__attribute__((used))
+caddr_t _sbrk_r(struct _reent *r, int incr) {
+#if CH_CFG_USE_MEMCORE
+  void *p;
+
+  chDbgCheck(incr >= 0);
+
+  p = chCoreAlloc((size_t)incr);
+  if (p == NULL) {
+    __errno_r(r) = ENOMEM;
+    return (caddr_t)-1;
+  }
+  return (caddr_t)p;
+#else
+  (void)incr;
+  __errno_r(r) = ENOMEM;
+  return (caddr_t)-1;
+#endif
+}
+
+__attribute__((used))
+int _fstat(int file, struct stat *st) {
+  st->st_mode = S_IFCHR;
+  return 0;
+}
+
+__attribute__((used))
+int _isatty(int file) {
+	return 1;
+}
+
+__attribute__((used))
+int _lseek(int file, int ptr, int dir) {
+	return 0;
+}


### PR DESCRIPTION
implemented:
- _write: only works for STDOUT and STDERR, EBADF otherwise
- _read: always returns 0
- _close: always returns 0
- _sbrk: use chCoreAlloc
- _fstat: set st->st_mode=S_IFCHR; return 0
- _isatty: always returns 1
- _lseek: always return 0